### PR TITLE
Client: Implemented ToUnicodeEx in Chat

### DIFF
--- a/StrawberryPie/System/Interface/Chat.cpp
+++ b/StrawberryPie/System/Interface/Chat.cpp
@@ -8,7 +8,7 @@
 
 NAMESPACE_BEGIN;
 
-#include <windows.h> //Winuser.h
+#include <Windows.h> //Winuser.h
 
 Chat::Chat()
 {

--- a/StrawberryPie/System/Interface/Chat.cpp
+++ b/StrawberryPie/System/Interface/Chat.cpp
@@ -110,7 +110,7 @@ void Chat::OnKeyDown(uint32_t c)
 		return;
 	}
 
-	if (c >= 0 && c <= 255) {
+	if (c <= 255) {
 		wchar_t wcharBuffer[10];
 
 		unsigned char keystate[256]; //using _pGame->m_keyStates does not work


### PR DESCRIPTION
Welp look at the title ¯\_(ツ)_/¯

But we really shouldn't us the "multiplayer_chat" scaleform as this thing doesn't really support special characters.
